### PR TITLE
docs: document local development scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # PUBG Character Viewer 🎮
 
 Built with IONIC, this application allows players of the game PUBG to view stats related both to their character and related matches.
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Serve the app locally with live reload:
+
+```bash
+npm run ionic:serve
+```
+
+Other useful scripts:
+
+| Script | Description |
+| --- | --- |
+| `npm run build` | Build the app |
+| `npm run build:www` | Production build into `www/` |
+| `npm run lint` | Lint the source |
+| `npm run clean` | Remove build artifacts |


### PR DESCRIPTION
The npm scripts for serving, building, and linting the app already existed in `package.json` but weren't discoverable from the README, which only described what the app does.

This adds a short **Development** section documenting them, so anyone landing on the repo can get it running without opening `package.json`. Every script listed is taken directly from `package.json` — no code or config is touched, README only.